### PR TITLE
Enable usage of local use/include statements

### DIFF
--- a/scad-mode.el
+++ b/scad-mode.el
@@ -296,7 +296,8 @@ Options are .stl, .off, .amf, .3mf, .csg, .dxf, .svg, .pdf, .png,
       (scad--preview-status "Dead")
     (scad--preview-kill)
     (scad--preview-status "Render")
-    (let* ((infile (make-temp-file "scad-preview-" nil ".scad"))
+    (let* ((temporary-file-directory default-directory)
+           (infile (make-temp-file "scad-preview-" nil ".scad"))
            (outfile (concat infile ".png"))
            (buffer (current-buffer)))
       (with-current-buffer scad--preview-buffer
@@ -435,6 +436,7 @@ Options are .stl, .off, .amf, .3mf, .csg, .dxf, .svg, .pdf, .png,
   (when (process-live-p scad--flymake-proc)
     (delete-process scad--flymake-proc))
   (let* ((buffer (current-buffer))
+         (temporary-file-directory default-directory)
          (infile (make-temp-file "scad-flymake-" nil ".scad"))
          (outfile (concat infile ".ast")))
     (save-restriction


### PR DESCRIPTION
Openscad enables code re-use via the include and use methods. https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Include_Statement This change generates the temporary file for the scad buffer in the default-directory so local files can be found via use or include statements during preview or flymake operations.